### PR TITLE
ENV for Google Credentials in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:14
 WORKDIR /usr/src/app
 COPY . /usr/src/app/
-
+ENV GOOGLE_APPLICATION_CREDENTIALS=bigQueryServiceCredentials.json
 RUN npm install 
 RUN npm install -g ts-node


### PR DESCRIPTION
### Summary

- ENV setting for Dockerfile

### Changes being made

`ENV GOOGLE_APPLICATION_CREDENTIALS=bigQueryServiceCredentials.json`